### PR TITLE
Removed unused `IntoPy` trait

### DIFF
--- a/crates/bindings/src/convert.rs
+++ b/crates/bindings/src/convert.rs
@@ -94,15 +94,6 @@ impl<T: Into<NDimImage>> IntoNumpy for T {
     }
 }
 
-pub trait IntoPy {
-    fn into_py(self, py: Python<'_>) -> &PyArray3<f32>;
-}
-impl<T: IntoNumpy> IntoPy for T {
-    fn into_py(self, py: Python<'_>) -> &PyArray3<f32> {
-        self.into_numpy().into_pyarray(py)
-    }
-}
-
 pub trait LoadImage<T> {
     fn load_image(self) -> PyResult<T>;
 }


### PR DESCRIPTION
Seems like clippy got smarter, which causes CI to fail in #30.