### PR TITLE
Bump/pyo3 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.20.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef41cbb417ea83b30525259e30ccef6af39b31c240bda578889494c5392d331"
+checksum = "29f1dee9aa8d3f6f8e8b9af3803006101bb3653866ef056d530d53ae68587191"
 dependencies = [
  "libc",
  "ndarray",
@@ -892,6 +892,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pyo3",
+ "pyo3-build-config",
  "rustc-hash",
 ]
 
@@ -1020,25 +1021,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.69"
+name = "portable-atomic"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.20.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset 0.9.0",
- "parking_lot",
+ "once_cell",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1047,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1057,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1067,33 +1074,34 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1186,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -1322,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1333,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "test-util"

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -12,8 +12,8 @@ name = "chainner_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.20.0", features = ["extension-module"] }
-numpy = "0.20.0"
+pyo3 = { version = "0.25.1", features = ["extension-module"] }
+numpy = "0.25.0"
 arboard = "3.2.0"
 
 glam.workspace = true

--- a/crates/bindings/pyproject.toml
+++ b/crates/bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "chainner_ext"
-version = "0.3.10"
+version = "0.3.11"
 description = "Rust implementation of functionality used in chaiNNer"
 requires-python = ">=3.7"
 classifiers = [

--- a/crates/bindings/src/convert.rs
+++ b/crates/bindings/src/convert.rs
@@ -2,7 +2,10 @@ use image_core::{
     util::slice_as_chunks, FromFlat, Image, ImageView, IntoPixels, NDimCow, NDimImage, NDimView,
     Shape, ShapeMismatch, Size,
 };
-use numpy::{ndarray::{Array3, Dimension}, Ix3, PyReadonlyArray, PyReadonlyArray2, PyReadonlyArray3, PyUntypedArrayMethods};
+use numpy::{
+    ndarray::{Array3, Dimension},
+    Ix3, PyReadonlyArray, PyReadonlyArray2, PyReadonlyArray3, PyUntypedArrayMethods,
+};
 use pyo3::{exceptions::PyValueError, FromPyObject, PyResult};
 
 #[derive(FromPyObject)]

--- a/crates/bindings/src/convert.rs
+++ b/crates/bindings/src/convert.rs
@@ -2,10 +2,7 @@ use image_core::{
     util::slice_as_chunks, FromFlat, Image, ImageView, IntoPixels, NDimCow, NDimImage, NDimView,
     Shape, ShapeMismatch, Size,
 };
-use numpy::{
-    ndarray::{Array3, Dimension},
-    Ix3, PyReadonlyArray, PyReadonlyArray2, PyReadonlyArray3,
-};
+use numpy::{ndarray::{Array3, Dimension}, Ix3, PyReadonlyArray, PyReadonlyArray2, PyReadonlyArray3, PyUntypedArrayMethods};
 use pyo3::{exceptions::PyValueError, FromPyObject, PyResult};
 
 #[derive(FromPyObject)]

--- a/crates/bindings/src/dither.rs
+++ b/crates/bindings/src/dither.rs
@@ -137,7 +137,7 @@ pub fn quantize<'py>(
     py: Python<'py>,
     img: PyImage<'py>,
     quant: Quant,
-) -> PyResult<&'py PyArray3<f32>> {
+) -> PyResult<Bound<'py, PyArray3<f32>>> {
     match quant {
         Quant::Uniform(quant) => {
             let mut img: NDimImage = img.load_image()?;
@@ -152,7 +152,7 @@ pub fn quantize<'py>(
                 py: Python<'py>,
                 img: PyImage<'py>,
                 quant: impl Quantizer<P, P> + Sync,
-            ) -> PyResult<&'py PyArray3<f32>>
+            ) -> PyResult<Bound<'py, PyArray3<f32>>>
             where
                 P: Pixel + Send + FromFlat,
                 Image<P>: IntoNumpy,
@@ -186,7 +186,7 @@ pub fn ordered_dither<'py>(
     img: PyImage,
     quant: UniformQuantization,
     map_size: u32,
-) -> PyResult<&'py PyArray3<f32>> {
+) -> PyResult<Bound<'py, PyArray3<f32>>> {
     if !map_size.is_power_of_two() {
         return Err(PyValueError::new_err(format!(
             "Argument '{}' must be a power of 2.",
@@ -213,7 +213,7 @@ mod diffusion {
         Config(py, img): Config<'_>,
         quant: impl Quantizer<P, P> + Sync,
         algorithm: impl image_ops::dither::DiffusionAlgorithm + Send,
-    ) -> PyResult<&PyArray3<f32>>
+    ) -> PyResult<Bound<PyArray3<f32>>>
     where
         P: Pixel + Send + FromFlat,
         Image<P>: IntoNumpy,
@@ -230,7 +230,7 @@ mod diffusion {
         config: Config,
         quant: Quant,
         algorithm: impl image_ops::dither::DiffusionAlgorithm + Send,
-    ) -> PyResult<&PyArray3<f32>> {
+    ) -> PyResult<Bound<PyArray3<f32>>> {
         let c = config.1.channels();
         let err = Err(PyValueError::new_err(format!(
             "Argument '{}' does not have the right shape. Expected 1, 3, or 4 channels but found {}.",
@@ -261,7 +261,7 @@ pub fn error_diffusion_dither<'py>(
     img: PyImage<'py>,
     quant: Quant,
     algorithm: DiffusionAlgorithm,
-) -> PyResult<&'py PyArray3<f32>> {
+) -> PyResult<Bound<'py, PyArray3<f32>>> {
     use diffusion::*;
 
     let config: Config<'py> = Config(py, img);
@@ -289,7 +289,7 @@ mod riemersma {
     pub fn with_pixel_format<P>(
         Config(py, img, history_length, decay_ratio): Config<'_>,
         quant: impl Quantizer<P, P> + Sync,
-    ) -> PyResult<&PyArray3<f32>>
+    )  -> PyResult<Bound<PyArray3<f32>>>
     where
         P: Pixel + Send + FromFlat,
         Image<P>: IntoNumpy,
@@ -310,7 +310,7 @@ pub fn riemersma_dither<'py>(
     quant: Quant,
     history_length: u32,
     decay_ratio: f32,
-) -> PyResult<&'py PyArray3<f32>> {
+) -> PyResult<Bound<'py, PyArray3<f32>>> {
     if history_length < 2 {
         return Err(PyValueError::new_err(format!(
             "Argument '{}' must be at least 2.",

--- a/crates/bindings/src/dither.rs
+++ b/crates/bindings/src/dither.rs
@@ -289,7 +289,7 @@ mod riemersma {
     pub fn with_pixel_format<P>(
         Config(py, img, history_length, decay_ratio): Config<'_>,
         quant: impl Quantizer<P, P> + Sync,
-    )  -> PyResult<Bound<PyArray3<f32>>>
+    ) -> PyResult<Bound<PyArray3<f32>>>
     where
         P: Pixel + Send + FromFlat,
         Image<P>: IntoNumpy,

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -14,7 +14,7 @@ use crate::convert::{IntoNumpy, LoadImage, PyImage};
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn chainner_ext(_py: Python, m: &PyModule) -> PyResult<()> {
+fn chainner_ext(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<regex::RustRegex>()?;
     m.add_class::<regex::MatchGroup>()?;
     m.add_class::<regex::RegexMatch>()?;
@@ -42,7 +42,7 @@ fn chainner_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         threshold: f32,
         iterations: u32,
         fragment_count: u32,
-    ) -> PyResult<&'py PyArray3<f32>> {
+    ) -> PyResult<Bound<'py, PyArray3<f32>>> {
         let mut img = img.load_image()?;
         let result = py.allow_threads(|| {
             fill_alpha(
@@ -66,7 +66,7 @@ fn chainner_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         img: PyImage,
         threshold: f32,
         iterations: u32,
-    ) -> PyResult<&'py PyArray3<f32>> {
+    ) -> PyResult<Bound<'py, PyArray3<f32>>> {
         let mut img = img.load_image()?;
         let result = py.allow_threads(|| {
             fill_alpha(
@@ -88,7 +88,7 @@ fn chainner_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         threshold: f32,
         min_radius: u32,
         anti_aliasing: bool,
-    ) -> PyResult<&'py PyArray3<f32>> {
+    ) -> PyResult<Bound<'py, PyArray3<f32>>> {
         let mut img = img.load_image()?;
         let result = py.allow_threads(|| {
             fill_alpha(
@@ -113,7 +113,7 @@ fn chainner_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         threshold: f32,
         anti_aliasing: bool,
         extra_smoothness: Option<f32>,
-    ) -> PyResult<&'py PyArray3<f32>> {
+    ) -> PyResult<Bound<'py, PyArray3<f32>>> {
         let mut img: NDimImage = img.load_image()?;
         let result = py.allow_threads(|| {
             let aa = if anti_aliasing {
@@ -139,7 +139,7 @@ fn chainner_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         cutoff: f32,
         pre_process: bool,
         post_process: bool,
-    ) -> PyResult<&'py PyArray3<f32>> {
+    ) -> PyResult<Bound<'py, PyArray3<f32>>> {
         let img: Image<f32> = img.load_image()?;
         let result = py.allow_threads(|| {
             image_ops::esdt::esdf(&img, radius, cutoff, pre_process, post_process).into_numpy()
@@ -148,7 +148,7 @@ fn chainner_ext(_py: Python, m: &PyModule) -> PyResult<()> {
     }
 
     #[pyfn(m)]
-    fn fast_gamma<'py>(py: Python<'py>, img: PyImage, gamma: f32) -> PyResult<&'py PyArray3<f32>> {
+    fn fast_gamma<'py>(py: Python<'py>, img: PyImage, gamma: f32) -> PyResult<Bound<'py, PyArray3<f32>>>  {
         let mut img = img.load_image()?;
         let result = py.allow_threads(|| {
             image_ops::gamma::gamma_ndim(&mut img, gamma);

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -148,7 +148,11 @@ fn chainner_ext(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     }
 
     #[pyfn(m)]
-    fn fast_gamma<'py>(py: Python<'py>, img: PyImage, gamma: f32) -> PyResult<Bound<'py, PyArray3<f32>>>  {
+    fn fast_gamma<'py>(
+        py: Python<'py>,
+        img: PyImage,
+        gamma: f32,
+    ) -> PyResult<Bound<'py, PyArray3<f32>>> {
         let mut img = img.load_image()?;
         let result = py.allow_threads(|| {
             image_ops::gamma::gamma_ndim(&mut img, gamma);

--- a/crates/bindings/src/pixel_art.rs
+++ b/crates/bindings/src/pixel_art.rs
@@ -14,13 +14,13 @@ pub fn pixel_art_upscale<'py>(
     img: PyImage<'py>,
     algorithm: &str,
     scale: u32,
-) -> PyResult<&'py PyArray3<f32>> {
+) -> PyResult<Bound<'py, PyArray3<f32>>> {
     fn with_pixel_format<'py, P>(
         py: Python<'py>,
         img: PyImage<'py>,
         algorithm: &str,
         scale: u32,
-    ) -> PyResult<&'py PyArray3<f32>>
+    ) -> PyResult<Bound<'py, PyArray3<f32>>>
     where
         P: FromFlat
             + Default

--- a/crates/bindings/src/resize.rs
+++ b/crates/bindings/src/resize.rs
@@ -52,7 +52,7 @@ pub fn resize<'py>(
     new_size: (u32, u32),
     filter: ResizeFilter,
     mut gamma_correction: bool,
-) -> PyResult<&'py PyArray3<f32>> {
+) -> PyResult<Bound<'py, PyArray3<f32>>> {
     let new_size: Size = new_size.into();
     let filter: Filter = filter.into();
 
@@ -146,7 +146,7 @@ pub fn resize<'py>(
             img: ImageView<'_, P>,
             new_size: Size,
             filter: Filter,
-        ) -> PyResult<&'py PyArray3<f32>>
+        ) -> PyResult<Bound<'py, PyArray3<f32>>>
         where
             P: Flatten + ClipFloat + Default + Copy + Sync + Send + 'static,
             FloatPixelFormat<P>: PixelFormat<InputPixel = P, OutputPixel = P>,
@@ -224,7 +224,7 @@ pub fn resize<'py>(
         img: Image<P>,
         new_size: Size,
         filter: Filter,
-    ) -> PyResult<&PyArray3<f32>>
+    ) -> PyResult<Bound<PyArray3<f32>>>
     where
         P: Flatten + ClipFloat + Default + Copy + Send + 'static,
         FloatPixelFormat<P>: PixelFormat<InputPixel = P, OutputPixel = P>,


### PR DESCRIPTION
Bruh, you could have made dev... In general, I increased the version of pyo3 and numpy-rs, so that chainner-ext could support python 3.13 and numpy 2.0
